### PR TITLE
Bug(#36): Bug lors de la réinitialisation des données

### DIFF
--- a/public/views/options.html
+++ b/public/views/options.html
@@ -78,6 +78,7 @@
             <input
                 type="color"
                 id="color"
+                value="#FF0000"
             >
             </select>
         </section>

--- a/src/trick-list-options.ts
+++ b/src/trick-list-options.ts
@@ -20,7 +20,6 @@ export class TrickListOptions {
 
     constructor() {
         document.addEventListener('DOMContentLoaded', () => TrickListOptions._init());
-        document.getElementById('formation').addEventListener('change', () => TrickListOptions._showFormationMode());
     }
 
     /**
@@ -31,6 +30,7 @@ export class TrickListOptions {
         TrickListOptions._restoreOptions();
         TrickListOptions._displayCategories();
 
+        document.getElementById('formation').addEventListener('change', () => TrickListOptions._showFormationMode());
         document.getElementById('save').addEventListener('click', TrickListOptions._saveOptions);
         document.getElementById('url-submit').addEventListener('click', TrickListOptions._addTricksFromURL);
         document.getElementById('reset-storage').addEventListener('click', TrickListOptions._resetTricks);
@@ -294,16 +294,34 @@ export class TrickListOptions {
      * @description Clear all list of tricks and options preferences
      */
     private static _resetTricks(): void {
-        TrickListOptions._categories = [];
+        chrome.storage.sync.clear();
+
         TrickListOptions._trickPreferences = [];
         TrickListOptions._urlList = [];
+        TrickListOptions._tricksFromUrl = [];
 
         TrickList.forEach(() => {
             TrickList.pop();
         });
 
-        chrome.storage.sync.clear();
-        TrickListOptions._restoreOptions();
+        const defaultColor = '#FF0000';
+
+        chrome.storage.sync.set({
+            config: {
+                favoriteColor: defaultColor,
+            },
+            formation: {
+                isActivated: false,
+                tricksNameChecked: JSON.stringify(TrickListOptions._trickPreferences),
+                detailIsActivated: false,
+            },
+            extTricks: {
+                tricksFromUrl: JSON.stringify(TrickListOptions._tricksFromUrl),
+                urlList: JSON.stringify(TrickListOptions._urlList),
+            },
+        } as ChromeStorageType);
+
+        TrickListOptions._init();
     }
 }
 


### PR DESCRIPTION
## Description

<!-- But / contenu de la pull request -->
- Ajout d'un `chome.storage.sync.set` pour immédiatement réassigner les variables vidé après un appui sur le bouton restaurer
- Ajout d'une couleur par défaut pour le thème
- Fix du bug d'écoute d'évènement pour la checkbox du mode formation après un restore

## Ticket de référence

Closes #36 

## Captures d'écrans / Vidéos

<!-- Joindre des captures & vidéos si nécessaires -->
![image](https://user-images.githubusercontent.com/82021898/117273278-4737de00-ae5c-11eb-9b66-c9b7f9c8e323.png)
![image](https://user-images.githubusercontent.com/82021898/117273371-5dde3500-ae5c-11eb-9aa2-194f7ab96075.png)


---

[Rappel des conventions](https://github.com/needone/sfts-docs/wiki/Conventions-de-langue-&-autres)
