### PR TITLE
refractor(#46):Removed 'Afficher les details' in options

### DIFF
--- a/public/views/options.html
+++ b/public/views/options.html
@@ -65,12 +65,6 @@
             />
             <label for="formation">Mode formation</label>
             <br>
-            <input
-                type="checkbox"
-                id="details"
-                name="details"
-            />
-            <label for="details">Afficher les détails</label>
         </section>
         <h2>Catégories</h2>
         <section id="categories"></section>

--- a/src/github-review-script.ts
+++ b/src/github-review-script.ts
@@ -144,13 +144,7 @@ export class GithubReviewScripts {
                     trickCaptured = ` ${trickCaptured}`;
                 }
 
-                let trickDetails = '';
-
-                if (items.formation !== undefined && items.formation.detailIsActivated) {
-                    trickDetails = trick.details;
-                }
-
-                htmlTricks += `<span title="${trickDetails}" style="color:${trick.color}">${trick.emoji}${trickCaptured}</span>`;
+                htmlTricks += `<span title="${trick.details}" style="color:${trick.color}">${trick.emoji}${trickCaptured}</span>`;
 
                 if (index + 1 < matchTricksUnique.length) {
                     htmlTricks += ' - ';

--- a/src/trick-list-options.ts
+++ b/src/trick-list-options.ts
@@ -137,7 +137,6 @@ export class TrickListOptions {
                 (document.getElementById('color') as HTMLInputElement).value = items.config.favoriteColor;
                 document.body.style.backgroundColor = (document.getElementById('color') as HTMLInputElement).value;
                 (document.getElementById('formation') as HTMLInputElement).checked = items.formation.isActivated;
-                (document.getElementById('details') as HTMLInputElement).checked = items.formation.detailIsActivated;
 
                 // Set default tricks from api storage
                 if (items.formation.tricksNameChecked.length !== 0) {

--- a/src/types/chrome-storage.type.ts
+++ b/src/types/chrome-storage.type.ts
@@ -5,7 +5,6 @@ export type ChromeStorageType = {
     formation: {
         isActivated: boolean;
         tricksNameChecked: string;
-        detailIsActivated: boolean;
     };
     extTricks: {
         tricksFromUrl: string;


### PR DESCRIPTION
## Description

<!-- But / contenu de la pull request -->
- Les details des tricks sont maintenant systématiquement activés
- La checkbox "Afficher les details" n'existe plus dans les options

## Ticket de référence

Closes #46 

## Captures d'écrans / Vidéos

<!-- Joindre des captures & vidéos si nécessaires -->
![image](https://user-images.githubusercontent.com/82021898/120338348-7115e080-c2f4-11eb-982c-c22bf3ee5d05.png)

---

[Rappel des conventions](https://github.com/needone/sfts-docs/wiki/Conventions-de-langue-&-autres)
